### PR TITLE
Separate Channel and Socket modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ use Absinthe.Phoenix.Endpoint
 In your socket add:
 
 ```elixir
-use Absinthe.Phoenix.Channel
+use Absinthe.Phoenix.Socket
 ```
 
 You also need to configure the schema by adding it to the socket assigns. Here
@@ -37,16 +37,12 @@ is an example socket:
 ```elixir
 defmodule GitHunt.Web.UserSocket do
   use Phoenix.Socket
-  use Absinthe.Phoenix.Channel
+  use Absinthe.Phoenix.Socket
 
   transport :websocket, Phoenix.Transports.WebSocket
 
   def connect(_params, socket) do
-    socket = socket |> assign(:absinthe, %{
-      schema: MyApp.Web.Schema,
-    })
-
-    {:ok, socket}
+    {:ok, assign(socket, :absinthe, %{schema: MyApp.Web.Schema})}
   end
 
   def id(_socket), do: nil

--- a/lib/absinthe/phoenix/channel.ex
+++ b/lib/absinthe/phoenix/channel.ex
@@ -2,12 +2,6 @@ defmodule Absinthe.Phoenix.Channel do
   use Phoenix.Channel
   require Logger
 
-  defmacro __using__(_) do
-    quote do
-      channel "__absinthe__:*", unquote(__MODULE__)
-    end
-  end
-
   @doc false
   def join("__absinthe__:control", _, socket) do
     defaults_opts = [

--- a/lib/absinthe/phoenix/socket.ex
+++ b/lib/absinthe/phoenix/socket.ex
@@ -1,0 +1,27 @@
+defmodule Absinthe.Phoenix.Socket do
+  @moduledoc ~S"""
+  `Absinthe.Phoenix.Socket` is used as a module for setting up a control
+  channel for handling GraphQL subscriptions.
+
+  ## Example
+
+      defmodule MyApp.Web.UserSocket do
+        use Phoenix.Socket
+        use Absinthe.Phoenix.Socket
+
+        transport :websocket, Phoenix.Transports.WebSocket
+
+        def connect(_params, socket) do
+          {:ok, assign(socket, :absinthe, %{schema: MyApp.Web.Schema})}
+        end
+
+        def id(_socket), do: nil
+      end
+    """
+
+  defmacro __using__(_) do
+    quote do
+      channel "__absinthe__:*", Absinthe.Phoenix.Channel
+    end
+  end
+end

--- a/lib/absinthe_phoenix.ex
+++ b/lib/absinthe_phoenix.ex
@@ -1,2 +1,0 @@
-defmodule Absinthe.Phoenix do
-end


### PR DESCRIPTION
This PR separates the `__using__/1` macro into an `Absinthe.Phoenix.Socket` module
in order to make it more consistent with `use Phoenix.Socket`.

* Added moduledoc
* Updated README