### PR TITLE
Let clients join subscription topics.

### DIFF
--- a/lib/absinthe/phoenix/channel.ex
+++ b/lib/absinthe/phoenix/channel.ex
@@ -33,6 +33,9 @@ defmodule Absinthe.Phoenix.Channel do
   end
 
   @doc false
+  def join("__absinthe__:doc:" <> _, _, socket), do: {:ok, socket}
+
+  @doc false
   def handle_in("doc", payload, socket) do
     config = socket.assigns[:absinthe]
     config = put_in(config.opts[:variables], Map.get(payload, "variables", %{}))


### PR DESCRIPTION
Hi, I've just added some [options for Apollo-Phoenix-Websocket][1] to let it work
fine with Absinthe subscriptions, I'm using the Absinthe `subscription` branch and
the latest master from absinthe_phoenix, everything went pretty smooth except for
one tiny thing I noticed:

The subscription response yields a `subscriptionId` and the code from absinthe_phoenix
effectively [sends data][2] via that topic with a `subscription:data` event.
But if the client tries to join the topic which looks like `__absinthe__:doc:31321`
there's no `join` clause on the Channel module to match it.

This patch just implements the missing join, so that clients can actually join their
subscription topics.

[1]: https://github.com/vic/apollo-phoenix-websocket/commit/ee5749657048ae28ba0214d93a14e76ebf83fc4f#diff-1fdf421c05c1140f6d71444ea2b27638R11
[2]: https://github.com/absinthe-graphql/absinthe_phoenix/blob/master/lib/absinthe/phoenix/endpoint.ex#L28