### PR TITLE
Provide execution context for document resolution.

### DIFF
--- a/lib/absinthe/phoenix/channel.ex
+++ b/lib/absinthe/phoenix/channel.ex
@@ -36,6 +36,7 @@ defmodule Absinthe.Phoenix.Channel do
   def handle_in("doc", payload, socket) do
     config = socket.assigns[:absinthe]
     config = put_in(config.opts[:variables], Map.get(payload, "variables", %{}))
+    config = put_in(config.opts[:context], Map.get(payload, "context", %{}))
 
     query = Map.get(payload, "query", "")
 

--- a/test/absinthe_phoenix_test.exs
+++ b/test/absinthe_phoenix_test.exs
@@ -29,6 +29,18 @@ defmodule Absinthe.PhoenixTest do
     }
   end
 
+  test "can provide execution context (ie for authorization)", %{socket: socket} do
+    ref = push socket, "doc", %{
+      "query" => "{viewer { name }}",
+      "context" => %{"authorization" => "jwt_token"}
+    }
+
+    assert_reply ref, :ok, reply
+    assert reply == %{
+      data: %{"viewer" => %{"name" => "Jane"}}
+    }
+  end
+
   test "basic query works with errors", %{socket: socket} do
     ref = push socket, "doc", %{
       "query" => "{users { errorField }}"

--- a/test/support/schema.ex
+++ b/test/support/schema.ex
@@ -19,6 +19,15 @@ defmodule Schema do
         {:ok, users}
       end
     end
+
+    field :viewer, :user do
+      resolve fn
+        _, _, %{context: %{"authorization" => "jwt_token"}} ->
+          {:ok, %{name: "Jane", age: 25}}
+        _, _, _ ->
+          {:error, :no_current_session}
+      end
+    end
   end
 
   mutation do


### PR DESCRIPTION
Let the phoenix channel provide execution context if its available
on the request payload. This way resolve functions can have access
to context values (in adition to the document variables), for
example, some middleware can be set to send always send the user
authorization token to provide a context for the query being
executed.

Tests implement a simple `viewer` query that resolve to a user
if provided a "jwt_token" value on context.

Closes #8 