### PR TITLE
Only require poison in test and dev

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -37,7 +37,7 @@ defmodule Absinthe.Phoenix.Mixfile do
       {:phoenix, "~> 1.0 or ~> 1.3.0-rc"},
       {:phoenix_pubsub, "~> 1.0 or ~> 1.3.0-rc"},
       {:ex_doc, "~> 0.14", only: :dev},
-      {:poison, "~> 2.0"},
+      {:poison, "~> 2.0"}, only: [:dev, :test]},
     ]
   end
 end


### PR DESCRIPTION
I was wondering why I couldn't update poison to version 3.0 with `absinthe_phoenix` as a dependency and discovered that version `2.0` is required.

Because I didn't see where except in the tests it is used I tried to limit the dependency to only the test and dev environments. Would that work?