### PR TITLE
Update README: topic -> config

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,8 @@ subscription do
     # subscription {
     #   commentAdded(repoFullName: "elixir-lang/elixir") { content }
     # }
-    topic fn args ->
-      args.repo_full_name
+    config fn args, _ ->
+      {:ok, topic: args.repo_full_name}
     end
 
     # this tells Absinthe to run any subscriptions with this field every time


### PR DESCRIPTION
since `topic`macro has been deprecated readme should use `config`.
I hope the code is correct