### PR TITLE
Send query errors back as error reply over the channel

### DIFF
--- a/lib/absinthe/phoenix/channel.ex
+++ b/lib/absinthe/phoenix/channel.ex
@@ -58,14 +58,16 @@ defmodule Absinthe.Phoenix.Channel do
           fastlane: {socket.transport_pid, socket.serializer, []},
           link: true,
         ])
-
         socket = Absinthe.Phoenix.Socket.put_opts(socket, context: context)
-
         {{:ok, %{subscriptionId: topic}}, socket}
 
-      {:ok, reply, context} ->
+      {:ok, %{data: _} = reply, context} ->
         socket = Absinthe.Phoenix.Socket.put_opts(socket, context: context)
         {{:ok, reply}, socket}
+
+      {:ok, %{errors: _} = reply, context} ->
+        socket = Absinthe.Phoenix.Socket.put_opts(socket, context: context)
+        {{:error, reply}, socket}
 
       {:error, reply} ->
         {reply, socket}


### PR DESCRIPTION
This way the channel can call the reject function when a query fails
due to a programmer error; otherwise errors like these would be
silently treated as succesful queries, leading to strange results
further down.