### PR TITLE
Add support for Absinthe continuations

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -43,7 +43,7 @@ defmodule Absinthe.Phoenix.Mixfile do
   defp deps do
     [
       {:absinthe_plug, "~> 1.5.0-alpha.0"},
-      {:absinthe, "~> 1.5.0-alpha.0"},
+      {:absinthe, github: "hippware/absinthe", branch: "defer-directive", override: true},
       {:decimal, "~> 1.0"},
       {:phoenix, "~> 1.4"},
       {:phoenix_pubsub, "~> 1.0"},

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{
-  "absinthe": {:hex, :absinthe, "1.5.0-alpha.4", "fa6dbd492db949a1193c57ddf9f382c55247082774b2b7ddd1bb44c4472e1a6b", [:mix], [{:dataloader, "~> 1.0.0", [hex: :dataloader, repo: "hexpm", optional: true]}, {:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}, {:nimble_parsec, "~> 0.4", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
+  "absinthe": {:git, "https://github.com/hippware/absinthe.git", "1a57e68b43684f19a5f68cef8113425b117833b1", [branch: "defer-directive"]},
   "absinthe_plug": {:hex, :absinthe_plug, "1.5.0-alpha.0", "6b81b11cd4965b87a1519e3ba6693c84a6462c1992b5e0191ed532c77594a728", [:mix], [{:absinthe, "~> 1.5.0-alpha.0", [hex: :absinthe, repo: "hexpm", optional: false]}, {:plug, "~> 1.3.2 or ~> 1.4", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm"},
   "decimal": {:hex, :decimal, "1.7.0", "30d6b52c88541f9a66637359ddf85016df9eb266170d53105f02e4a67e00c5aa", [:mix], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.3.2", "b840562ea3d67795ffbb5bd88940b1bed0ed9fa32834915125ea7d02e35888a5", [:mix], [], "hexpm"},

--- a/test/absinthe/async_test.exs
+++ b/test/absinthe/async_test.exs
@@ -1,0 +1,73 @@
+defmodule Absinthe.AsyncTest do
+  use ExUnit.Case
+  use Absinthe.Phoenix.ChannelCase
+
+  setup_all do
+    Absinthe.Test.prime(Schema)
+
+    {:ok, _} = Absinthe.Phoenix.TestEndpoint.start_link()
+    {:ok, _} = Absinthe.Subscription.start_link(Absinthe.Phoenix.TestEndpoint)
+    :ok
+  end
+
+  test "defer sync" do
+    socket = get_socket(0)
+    query = %{"query" => "query { slow_field (delay: 400) { value @defer } }"}
+    ref = push(socket, "doc", query)
+    refute_reply(ref, _, _, 200)
+
+    query = %{"query" => "query { slow_field (delay: 100) { value @defer } }"}
+    ref2 = push(socket, "doc", query)
+
+    # This second query will be blocked by the first because there are no async
+    # threads left to handle it
+    assert_reply(ref, :ok, %{queryId: id1}, 500)
+    assert_push("doc", reply)
+    assert reply.queryId == id1
+    assert reply.data == 400
+
+    assert_reply(ref2, :ok, %{queryId: id2}, 200)
+    assert_push("doc", reply)
+    assert reply.queryId == id2
+    assert reply.data == 100
+  end
+
+  test "repeated async defers" do
+    socket = get_socket(2)
+
+    # Run the test multiple times to ensure that completed async tasks are
+    # cleaned up and don't prevent subsequent queries being handled
+    # asynchronously
+    Enum.each(1..3, fn _ ->
+      query = %{"query" => "query { slow_field (delay: 400) { value @defer } }"}
+      ref = push(socket, "doc", query)
+      assert_reply(ref, :ok, %{queryId: id1})
+
+      query = %{"query" => "query { slow_field (delay: 100) { value @defer } }"}
+      ref = push(socket, "doc", query)
+      assert_reply(ref, :ok, %{queryId: id2})
+
+      # This second query is faster so its deferred result should arrive before
+      # the first query's
+      assert_push("doc", reply, 200)
+      assert reply.queryId == id2
+      assert reply.data == 100
+
+      assert_push("doc", reply, 400)
+      assert reply.queryId == id1
+      assert reply.data == 400
+    end)
+  end
+
+  defp get_socket(max_async_procs) do
+    {:ok, _, socket} =
+      "asdf"
+      |> socket(
+        absinthe: %{schema: Schema, opts: []},
+        max_async_procs: max_async_procs
+      )
+      |> subscribe_and_join(Absinthe.Phoenix.Channel, "__absinthe__:control")
+
+    socket
+  end
+end

--- a/test/absinthe/phoenix_test.exs
+++ b/test/absinthe/phoenix_test.exs
@@ -216,4 +216,17 @@ defmodule Absinthe.PhoenixTest do
              error: "Could not parse variables as map"
            }
   end
+
+  test "defer", %{socket: socket} do
+    ref = push socket, "doc", %{"query" => "query { users { name @defer } }"}
+    assert_reply ref, :ok, %{queryId: id, data: data}
+    assert data == %{"users" => [%{}]}
+
+    assert_push "doc", reply
+    assert reply== %{
+      queryId: id,
+      data: "Bob",
+      path: ["users", 0, "name"]
+    }
+  end
 end

--- a/test/support/schema.ex
+++ b/test/support/schema.ex
@@ -27,6 +27,15 @@ defmodule Schema do
     field :age, :integer
   end
 
+  object :slow_field do
+    field :value, :integer do
+      resolve fn %{value: value}, _, _ ->
+        Process.sleep(value)
+        {:ok, value}
+      end
+    end
+  end
+
   query do
     field :me, :user do
       resolve fn _, %{context: context} ->
@@ -41,6 +50,12 @@ defmodule Schema do
         ]
 
         {:ok, users}
+      end
+    end
+    field :slow_field, :slow_field do
+      arg :delay, non_null(:integer)
+      resolve fn _, args, _ ->
+        {:ok, %{value: args.delay}}
       end
     end
   end


### PR DESCRIPTION
This change adds support for continuations and the `@defer` directive as implemented in https://github.com/absinthe-graphql/absinthe/pull/559. It's not meant to be merged until that one's all done (the dependency in `mix.exs` will need updating), but I figured I'd put it here now so that it's ready to go.

Of note: There's support for asynchronous handling of continuations (as discussed in https://github.com/absinthe-graphql/absinthe/pull/559#issuecomment-398376278), but it's off by default. To enable it, the endpoint can be started with the `max_async_procs` flag (see `socket/1` in `async_test.exs`), specifying the maximum number of temporary processes used to handle asynchronous queries. Beyond that number, queries using `@defer` will be blocked as usual on long running requests.