### PR TITLE
Fix override of custom pubsub set in socket context

### DIFF
--- a/lib/absinthe/phoenix/channel.ex
+++ b/lib/absinthe/phoenix/channel.ex
@@ -24,7 +24,7 @@ defmodule Absinthe.Phoenix.Channel do
       absinthe_config
       |> Map.get(:opts, [])
       |> Keyword.update(:context, %{pubsub: socket.endpoint}, fn context ->
-        Map.put(context, :pubsub, socket.endpoint)
+        Map.put_new(context, :pubsub, socket.endpoint)
       end)
 
     absinthe_config =
@@ -87,9 +87,17 @@ defmodule Absinthe.Phoenix.Channel do
 
     {:reply, reply, socket}
   end
+
   def handle_in("unsubscribe", %{"subscriptionId" => doc_id}, socket) do
+    pubsub =
+      socket.assigns
+      |> Map.get(:absinthe, %{})
+      |> Map.get(:opts, [])
+      |> Keyword.get(:context, %{})
+      |> Map.get(:pubsub, socket.endpoint)
+
     Phoenix.PubSub.unsubscribe(socket.pubsub_server, doc_id)
-    Absinthe.Subscription.unsubscribe(socket.endpoint, doc_id)
+    Absinthe.Subscription.unsubscribe(pubsub, doc_id)
     {:reply, {:ok, %{subscriptionId: doc_id}}, socket}
   end
 


### PR DESCRIPTION
Absinthe Subscriptions appear to support a custom pubsub but when it comes down to joining the control channel it fails with `Pubsub not configured! Subscriptions require a configured pubsub module.` even though a compatible pubsub is passed to `Absinthe.Subscription` on start and `:pubsub` is added to the socket's context.

I found that the channel was manually setting the pubsub to `socket.endpoint` regardless of what was set as the pubsub in the context.