### PR TITLE
Make poison dep optional

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -8,9 +8,9 @@ defmodule Absinthe.Phoenix.Mixfile do
       app: :absinthe_phoenix,
       version: @version,
       elixir: "~> 1.4",
-      elixirc_paths: elixirc_paths(Mix.env),
-      build_embedded: Mix.env == :prod,
-      start_permanent: Mix.env == :prod,
+      elixirc_paths: elixirc_paths(Mix.env()),
+      build_embedded: Mix.env() == :prod,
+      start_permanent: Mix.env() == :prod,
       docs: [source_ref: "v#{@version}"],
       package: package(),
       deps: deps()
@@ -19,20 +19,22 @@ defmodule Absinthe.Phoenix.Mixfile do
 
   defp package do
     [
-      description: "Subscription support via Phoenix for Absinthe, the GraphQL implementation for Elixir.",
+      description:
+        "Subscription support via Phoenix for Absinthe, the GraphQL implementation for Elixir.",
       files: ["lib", "mix.exs", "README*"],
       maintainers: ["Ben Wilson", "Bruce Williams"],
       licenses: ["MIT"],
       links: %{
-        "Website": "https://absinthe-graphql.org",
-        "Changelog": "https://github.com/absinthe-graphql/absinthe_phoenix/blob/master/CHANGELOG.md", 
-        "GitHub": "https://github.com/absinthe-graphql/absinthe_phoenix"
+        Website: "https://absinthe-graphql.org",
+        Changelog:
+          "https://github.com/absinthe-graphql/absinthe_phoenix/blob/master/CHANGELOG.md",
+        GitHub: "https://github.com/absinthe-graphql/absinthe_phoenix"
       }
     ]
   end
 
   defp elixirc_paths(:test), do: ["lib", "test/support"]
-  defp elixirc_paths(_),     do: ["lib"]
+  defp elixirc_paths(_), do: ["lib"]
 
   def application do
     [extra_applications: [:logger]]
@@ -47,7 +49,7 @@ defmodule Absinthe.Phoenix.Mixfile do
       {:phoenix_pubsub, "~> 1.0"},
       {:phoenix_html, "~> 2.10.5 or ~> 2.11", optional: true},
       {:ex_doc, "~> 0.14", only: :dev},
-      {:poison, "~> 2.0 or ~> 3.0"},
+      {:poison, "~> 2.0 or ~> 3.0", only: [:dev, :test]}
     ]
   end
 end


### PR DESCRIPTION
Poison seems only required by test here. It's not a hard dependency
since the JSON decoding bits are delegated to plug if i'm not mistaken.