### PR TITLE
Fix default value for variables in push_doc

### DIFF
--- a/lib/absinthe/phoenix/channel_test.ex
+++ b/lib/absinthe/phoenix/channel_test.ex
@@ -34,7 +34,7 @@ defmodule Absinthe.Phoenix.SubscriptionTest do
   def push_doc(socket, query, opts \\ []) do
     Phoenix.ChannelTest.push(socket, "doc", %{
       "query" => query,
-      "variables" => opts[:variables]
+      "variables" => opts[:variables] || %{}
     })
   end
 end


### PR DESCRIPTION
Very small but important follow-up fix to https://github.com/absinthe-graphql/absinthe_phoenix/pull/53 - the test helper would default to sending `nil` as the variable list which is no longer accepted.