### PR TITLE
Fix `Absinthe.Phoenix.Controller` documentation.

### DIFF
--- a/lib/absinthe/phoenix/controller.ex
+++ b/lib/absinthe/phoenix/controller.ex
@@ -4,12 +4,13 @@ defmodule Absinthe.Phoenix.Controller do
 
   ## Example
 
-  First, `use Absinthe.Phoenix.Controller`, passing your `schema`:
+  First, `use Absinthe.Phoenix.Controller`, passing your `schema` and
+  notifying Absinthe to operate in `internal` mode:
 
   ```elixir
   defmodule MyAppWeb.UserController do
     use MyAppWeb, :controller
-    use Absinthe.Phoenix.Controller, schema: MyAppWeb.Schema
+    use Absinthe.Phoenix.Controller, schema: MyAppWeb.Schema, action: [mode: :internal]
 
     # ... actions
 


### PR DESCRIPTION
If one doesn't provide the `action: [mode: :internal]` addendum to the `use` statement then Absinthe returns results serialised as if it were about to convert it to JSON, rather than returning the unserialised data.  Most importantly this means that map keys are atoms rather than strings.

Thanks to @aspett for the tip.