### PR TITLE
version bump for latest absinthe_plug

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -42,7 +42,7 @@ defmodule Absinthe.Phoenix.Mixfile do
 
   defp deps do
     [
-      {:absinthe_plug, "~> 1.5.0-rc.0"},
+      {:absinthe_plug, "~> 1.5.0-rc.2"},
       {:absinthe, "~> 1.5.0-rc.0"},
       {:decimal, "~> 1.0"},
       {:phoenix, "~> 1.4"},


### PR DESCRIPTION

```error
Dependencies have diverged:
* absinthe_plug (Hex package)
  the :only option for dependency absinthe_plug

  > In apps/shared_utils/mix.exs:
    {:absinthe_plug, "~> 1.5.0-rc.2", [env: :prod, repo: "hexpm", hex: "absinthe_plug"]}

  does not match the :only option calculated for

  > In deps/absinthe_phoenix/mix.exs:
    {:absinthe_plug, "~> 1.5.0-rc.0", [env: :prod, hex: "absinthe_plug", repo: "hexpm", optional: false]}

  Remove the :only restriction from your dep
** (Mix) Can't continue due to errors on dependencies
```