### PR TITLE
Get rid of unnecessary Logger.debug/1 line

### DIFF
--- a/lib/absinthe/phoenix/channel.ex
+++ b/lib/absinthe/phoenix/channel.ex
@@ -1,6 +1,5 @@
 defmodule Absinthe.Phoenix.Channel do
   use Phoenix.Channel
-  require Logger
 
   @moduledoc false
 
@@ -55,14 +54,6 @@ defmodule Absinthe.Phoenix.Channel do
       })
 
       {reply, socket} = run_doc(socket, query, config, opts)
-
-      Logger.debug(fn ->
-        """
-        -- Absinthe Phoenix Reply --
-        #{inspect(reply)}
-        ----------------------------
-        """
-      end)
 
       if reply != :noreply do
         {:reply, reply, socket}


### PR DESCRIPTION
I've been trying to reduce the amount of DEBUG logs when working with subscriptions and found that these few lines where responsible for a lot of logs.

I would also like to propose a an other PR for passing extra opts to `Phoenix.Channel` in order to disable logging there (see [docs](https://hexdocs.pm/phoenix/Phoenix.Channel.html#module-logging)).