### PR TITLE
Check for empty variables when parsing subscription doc

### DIFF
--- a/lib/absinthe/phoenix/channel.ex
+++ b/lib/absinthe/phoenix/channel.ex
@@ -42,7 +42,7 @@ defmodule Absinthe.Phoenix.Channel do
   def handle_in("doc", payload, socket) do
     config = socket.assigns[:absinthe]
 
-    with variables when is_map(variables) <- Map.get(payload, "variables", %{}) do
+    with variables when is_map(variables) <- extract_variables(payload) do
       opts = Keyword.put(config.opts, :variables, variables)
 
       query = Map.get(payload, "query", "")
@@ -126,6 +126,13 @@ defmodule Absinthe.Phoenix.Channel do
 
       {:error, msg, _phases} ->
         {:error, msg}
+    end
+  end
+
+  defp extract_variables(payload) do
+    case Map.get(payload, "variables", %{}) do
+      nil -> %{}
+      map -> map
     end
   end
 

--- a/test/absinthe/phoenix_test.exs
+++ b/test/absinthe/phoenix_test.exs
@@ -221,4 +221,14 @@ defmodule Absinthe.PhoenixTest do
              error: "Could not parse variables as map"
            }
   end
+
+  test "empty variables succeed", %{socket: socket} do
+    ref =
+      push(socket, "doc", %{
+        "query" => "subscription {commentAdded { contents }}",
+        "variables" => nil
+      })
+
+    assert_reply(ref, :ok, %{subscriptionId: _subscription_ref})
+  end
 end


### PR DESCRIPTION
The GraphQL spec allows for empty variable map (nil) when submitting subscriptions over websockets. However using Map.get/3 will happily return nil as long as the "variables" key is present in the payload map, causing the is_map guard to fail.

I was hitting this issue on Apollo (iOS SDK) + SwiftPhoenixClient with a subscription that doesn't take any variables.