### PR TITLE
Support decimal v2

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -44,7 +44,7 @@ defmodule Absinthe.Phoenix.Mixfile do
     [
       {:absinthe_plug, "~> 1.5.0"},
       {:absinthe, "~> 1.5.0"},
-      {:decimal, "~> 1.0"},
+      {:decimal, "~> 1.0 or ~> 2.0"},
       {:phoenix, "~> 1.5"},
       {:phoenix_pubsub, "~> 2.0"},
       {:phoenix_html, "~> 2.13", optional: true},


### PR DESCRIPTION
Widened the range of decimal dependence.
If absinthe's decimal dependence is 1.0, I think there will be no problem because the dependence on absinthe's side takes precedence.

Note that no code change needed this time.

ref https://github.com/absinthe-graphql/absinthe/pull/975