### PR TITLE
allow Phoenix.HTML 3.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -56,7 +56,7 @@ defmodule Absinthe.Phoenix.Mixfile do
       {:decimal, "~> 1.0 or ~> 2.0"},
       {:phoenix, "~> 1.5"},
       {:phoenix_pubsub, "~> 2.0"},
-      {:phoenix_html, "~> 2.13", optional: true},
+      {:phoenix_html, "~> 2.13 or ~> 3.0", optional: true},
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
       {:jason, "~> 1.0", only: [:dev, :test]}
     ]


### PR DESCRIPTION
This loosens the version requirement for Phoenix.HTML, so that the library can be used in projects that use Phoenix.HTML 3.0 / LiveView 0.16.