### PR TITLE
Expand aliases in Absinthe.Phoenix.Socket

### DIFF
--- a/lib/absinthe/phoenix/socket.ex
+++ b/lib/absinthe/phoenix/socket.ex
@@ -28,6 +28,13 @@ defmodule Absinthe.Phoenix.Socket do
   """
 
   defmacro __using__(opts) do
+    opts =
+      if Macro.quoted_literal?(opts) do
+        Macro.prewalk(opts, &expand_alias(&1, __CALLER__))
+      else
+        opts
+      end
+
     schema = Keyword.get(opts, :schema)
     pipeline = Keyword.get(opts, :pipeline)
 
@@ -92,4 +99,9 @@ defmodule Absinthe.Phoenix.Socket do
 
     Phoenix.Socket.assign(socket, :absinthe, absinthe_assigns)
   end
+
+  defp expand_alias({:__aliases__, _, _} = alias, env),
+    do: Macro.expand(alias, %{env | function: {:__using__, 1}})
+
+  defp expand_alias(other, _env), do: other
 end


### PR DESCRIPTION
Since the schema isn't used at compile time, we're able to expand the alias and avoid creating an unnecessary compile dependency.

This change mirrors similar changes made in Phoenix today:
https://github.com/phoenixframework/phoenix/commit/55c83ba8c2899c9fce68d18dab66ff36ffaecf96
https://github.com/phoenixframework/phoenix/commit/c6bd2ad5ad1d0b9d130e452344d42623690f6121
https://github.com/phoenixframework/phoenix_live_dashboard/commit/bd13e934949620fce29ebc0b50dfb3ac3c19f298