### PR TITLE
Better subscription test helpers

### DIFF
--- a/lib/absinthe/phoenix/subscription_test.ex
+++ b/lib/absinthe/phoenix/subscription_test.ex
@@ -7,7 +7,22 @@ defmodule Absinthe.Phoenix.SubscriptionTest do
            [variables: Access.container()]
            | %{variables: Access.container()}
 
+  @doc false
   defmacro __using__(schema: schema) do
+    IO.warn """
+    Using Absinthe.Phoenix.SubscriptionTest is deprecated, instead of:
+
+        use Absinthe.Phoenix.SubscriptionTest, schema: MyApp.Schema
+
+    do:
+
+        import Absinthe.Phoenix.SubscriptionTest
+
+        setup_all do
+          Absinthe.Test.prime(MyApp.Schema)
+        end
+    """, Macro.Env.stacktrace(__CALLER__)
+
     quote do
       setup_all do
         Absinthe.Test.prime(unquote(schema))

--- a/lib/absinthe/phoenix/subscription_test.ex
+++ b/lib/absinthe/phoenix/subscription_test.ex
@@ -1,9 +1,37 @@
 defmodule Absinthe.Phoenix.SubscriptionTest do
   @moduledoc """
   Convenience functions for subscription tests.
+
+  ## Example
+
+      defmodule MyApp.SocketTest do
+        use ExUnit.Case
+        import Absinthe.Phoenix.SubscriptionTest
+
+        test "once unread thread is created, unread threads count changes subscription gets an update" do
+          socket = build_socket(MyApp.Endpoint, MyApp.Socket)
+
+          subscription_id =
+            start_subscription(socket, \"""
+              subscription {
+                unreadThreadsCountChanges {
+                  count
+                }
+              }
+            \""")
+
+          create_unread_thread()
+
+          assert_subscription_update(subscription_id, %{
+            "unreadThreadsCountChanges" => %{"count" => 1}
+          })
+
+          refute_subscription_update(subscription_id)
+        end
+      end
   """
 
-  @typep opts ::
+  @typep push_doc_opts ::
            [variables: Access.container()]
            | %{variables: Access.container()}
 
@@ -32,6 +60,121 @@ defmodule Absinthe.Phoenix.SubscriptionTest do
     end
   end
 
+  @doc ~S"""
+  Build a socket connection to a `Absinthe.Phoenix.Socket` using the given `Absinthe.Phoenix.Endpoint`.
+
+  Optionally pass `socket_params` which will will be passed to the `Absinthe.Phoenix.Socket.connect` function.
+
+  ## Example
+
+      AL.MobileApi.AbsinthePhoenixSocketTest.build_socket(
+        MyApp.Endpoint,
+        MyApp.Socket,
+        %{
+          "Authorization" => "Bearer #{auth_token}"
+        }
+      )
+  """
+  @spec build_socket(term(), term(), map()) :: reference()
+  def build_socket(endpoint, socket_module, socket_params \\ %{}) do
+    {:ok, socket} = Phoenix.ChannelTest.__connect__(endpoint, socket_module, socket_params, %{})
+    {:ok, socket} = join_absinthe(socket)
+    socket
+  end
+
+  @doc """
+  Start a GraphQL subscription using the given `socket` connection (built using `build_socket`).
+
+  Returns `subscription_id`.
+
+  ## Example
+
+      subscription_id =
+        start_subscription(socket, \"""
+          subscription {
+            unreadThreadsCountChanges {
+              count
+            }
+          }
+        \""")
+  """
+  @spec start_subscription(reference(), String.t(), keyword()) :: String.t()
+  defmacro start_subscription(
+             socket,
+             query,
+             opts \\ []
+           ) do
+    quote do
+      opts = unquote(opts)
+      variables = Keyword.get(opts, :variables, %{})
+      timeout = Keyword.get(opts, :timeout, Application.fetch_env!(:ex_unit, :assert_receive_timeout))
+
+      ref = Absinthe.Phoenix.SubscriptionTest.push_doc(unquote(socket), unquote(query), variables)
+
+      Phoenix.ChannelTest.assert_reply(
+        ref,
+        :ok,
+        %{subscriptionId: subscription_id},
+        timeout
+      )
+
+      subscription_id
+    end
+  end
+
+  @doc """
+  Assert that the GraphQL subscription has received data update.
+
+  ## Example
+
+      assert_subscription_update(subscription_id, %{
+        "unreadThreadsCountChanges" => %{"count" => 1}
+      })
+  """
+  @spec assert_subscription_update(String.t(), map(), integer()) :: nil
+  defmacro assert_subscription_update(
+             subscription_id,
+             data,
+             timeout \\ Application.fetch_env!(:ex_unit, :assert_receive_timeout)
+           ) do
+    quote do
+      Phoenix.ChannelTest.assert_push(
+        "subscription:data",
+        %{
+          subscriptionId: ^unquote(subscription_id),
+          result: %{
+            data: unquote(data)
+          }
+        },
+        unquote(timeout)
+      )
+    end
+  end
+
+  @doc """
+  Assert that the GraphQL subscription has received no data updates.
+
+  ## Example
+
+      refute_subscription_update(subscription_id)
+  """
+  @spec refute_subscription_update(String.t(), integer()) :: nil
+  defmacro refute_subscription_update(
+             subscription_id,
+             timeout \\ Application.fetch_env!(:ex_unit, :assert_receive_timeout)
+           ) do
+    quote do
+      Phoenix.ChannelTest.refute_push(
+        "subscription:data",
+        %{
+          subscriptionId: ^unquote(subscription_id)
+        },
+        unquote(timeout)
+      )
+    end
+  end
+
+  @doc false
   def join_absinthe(socket) do
     with {:ok, _, socket} <-
            Phoenix.ChannelTest.subscribe_and_join(socket, "__absinthe__:control", %{}) do
@@ -39,13 +182,8 @@ defmodule Absinthe.Phoenix.SubscriptionTest do
     end
   end
 
-  @doc """
-  A small wrapper around `Phoenix.ChannelTest.push/3`.
-
-  The only option that is used is `opts[:variables]` - all other options are
-  ignored.
-  """
-  @spec push_doc(Phoenix.Socket.t(), String.t(), opts) :: reference()
+  @doc false
+  @spec push_doc(Phoenix.Socket.t(), String.t(), push_doc_opts) :: reference()
   def push_doc(socket, query, opts \\ []) do
     Phoenix.ChannelTest.push(socket, "doc", %{
       "query" => query,

--- a/test/absinthe/phoenix/subscription_test_test.exs
+++ b/test/absinthe/phoenix/subscription_test_test.exs
@@ -1,0 +1,41 @@
+defmodule Absinthe.Phoenix.SubscriptionTestTest do
+  use ExUnit.Case
+  use Absinthe.Phoenix.ChannelCase
+  import Absinthe.Phoenix.SubscriptionTest
+
+  setup_all do
+    Absinthe.Test.prime(Schema)
+
+    children = [
+      {Phoenix.PubSub, [name: Absinthe.Phoenix.PubSub, adapter: Phoenix.PubSub.PG2]},
+      Absinthe.Phoenix.TestEndpoint,
+      {Absinthe.Subscription, Absinthe.Phoenix.TestEndpoint}
+    ]
+
+    {:ok, _} = Supervisor.start_link(children, strategy: :one_for_one)
+    :ok
+  end
+
+  test "subscription can be started and its' updates can be asserted" do
+    socket = build_socket(Absinthe.Phoenix.TestEndpoint, Absinthe.Phoenix.TestSocket)
+
+    subscription_id = start_subscription(socket, "subscription {commentAdded { contents }}")
+
+    ref =
+      push(socket, "doc", %{
+        "query" => "mutation ($contents: String!) {addComment(contents: $contents) { contents }}",
+        "variables" => %{"contents" => "hello world"}
+      })
+
+    assert_reply(ref, :ok, reply)
+
+    expected = %{data: %{"addComment" => %{"contents" => "hello world"}}}
+    assert expected == reply
+
+    assert_subscription_update(subscription_id, %{
+      "commentAdded" => %{"contents" => "hello world"}
+    })
+
+    refute_subscription_update(subscription_id)
+  end
+end

--- a/test/support/test_socket.ex
+++ b/test/support/test_socket.ex
@@ -1,6 +1,6 @@
 defmodule Absinthe.Phoenix.TestSocket do
   use Phoenix.Socket
-  use Absinthe.Phoenix.Socket
+  use Absinthe.Phoenix.Socket, schema: Schema
 
   def connect(_, socket, _connect_info) do
     {:ok, socket}


### PR DESCRIPTION
Solves https://github.com/absinthe-graphql/absinthe/issues/942 . 

Implements new test helpers that allow to start a graphql subscription and assert/refute its' updates using an easy-to-use syntax.

Docs for the old helpers have been removed, as they shouldn't be needed anymore. (They're still left as they're used internally by the new helpers, and because existing projects may use them.)

Let me know if anything needs to be improved before this can be merged.

P.S. This work here was inspired by https://github.com/gen1321/anise and https://gist.github.com/wpiekutowski/8e4de4b9c8253584765ca0106c190dad - thank you @gen1321 and @wpiekutowski !