### PR TITLE
Support Erlang OTP/26 and Elixir 15

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,44 +8,47 @@ on:
 
 jobs:
   test:
-    name: Elixir ${{matrix.elixir}} / OTP ${{matrix.otp}}
-    runs-on: ubuntu-latest
+    name: Elixir ${{matrix.pair.elixir}} / OTP ${{matrix.pair.otp}}
+    runs-on: ubuntu-20.04
 
     strategy:
       matrix:
-        elixir:
-          - '1.10'
-          - '1.11'
-        otp:
-          - '22'
-          - '23'
+        include:
+          - pair:
+              elixir: "1.11.x"
+              otp: "22.x"
+          - pair:
+              elixir: "1.15.x"
+              otp: "26.x"
+            lint: true
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Set up Elixir
-      uses: erlef/setup-elixir@v1
+      uses: erlef/setup-beam@v1
       with:
-        elixir-version: ${{ matrix.elixir }}
-        otp-version: ${{ matrix.otp }}
+        elixir-version: ${{ matrix.pair.elixir }}
+        otp-version: ${{ matrix.pair.otp }}
 
     - name: Restore deps cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           deps
           _build
-        key: deps-${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}-git-${{ github.sha }}
+        key: deps-${{ runner.os }}-${{ matrix.pair.otp }}-${{ matrix.pair.elixir }}-${{ hashFiles('**/mix.lock') }}-git-${{ github.sha }}
         restore-keys: |
-          deps-${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
-          deps-${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}
+          deps-${{ runner.os }}-${{ matrix.pair.otp }}-${{ matrix.pair.elixir }}-${{ hashFiles('**/mix.lock') }}
+          deps-${{ runner.os }}-${{ matrix.pair.otp }}-${{ matrix.pair.elixir }}
 
     - name: Install package dependencies
       run: mix deps.get
 
     - name: Check code format
       run: mix format --check-formatted
+      if: ${{ matrix.lint }}
 
     - name: Compile dependencies
       run: mix compile

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.15.4-otp-25
-erlang 25.2.2
+elixir 1.15.7-otp-26
+erlang 26.1.2

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule Absinthe.Phoenix.Mixfile do
     [
       app: :absinthe_phoenix,
       version: @version,
-      elixir: "~> 1.10",
+      elixir: "~> 1.11",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       package: package(),


### PR DESCRIPTION
List of changes:
- add Erlang OTP/26 and Elixir to GitHub CI
- bump GitHub actions
- bump asdf dev environment (.tool-versions)
- set Elixir 1.11 as minimum requirement