### PR TITLE
Adds an option to periodically run `:erlang.garbage_collect` on both the Channel and Transport processes

### DIFF
--- a/lib/absinthe/phoenix/channel.ex
+++ b/lib/absinthe/phoenix/channel.ex
@@ -151,6 +151,7 @@ defmodule Absinthe.Phoenix.Channel do
 
   def handle_info(:gc, socket) do
     :erlang.garbage_collect()
+    :erlang.garbage_collect(socket.transport_pid)
     Process.send_after(self(), :gc, socket.assigns.absinthe.gc_interval)
     {:noreply, socket}
   end

--- a/lib/absinthe/phoenix/socket.ex
+++ b/lib/absinthe/phoenix/socket.ex
@@ -58,7 +58,7 @@ defmodule Absinthe.Phoenix.Socket do
         assigns: %{
           __absinthe_schema__: unquote(schema),
           __absinthe_pipeline__: unquote(pipeline),
-          __absinthe_gc_interval: unquote(gc_interval)
+          __absinthe_gc_interval__: unquote(gc_interval)
         }
       )
     end

--- a/lib/absinthe/phoenix/socket.ex
+++ b/lib/absinthe/phoenix/socket.ex
@@ -25,6 +25,18 @@ defmodule Absinthe.Phoenix.Socket do
   ## Phoenix 1.2
 
   If you're on Phoenix 1.2 see `put_schema/2`.
+
+  ## Garbage Collection
+
+  In some workloads, the Channel Process responsible for handling [subscriptions may accumulate
+  some gargage](https://elixirforum.com/t/why-does-garbage-collection-not-work-as-intended/50613/2), that is not being collected by the Erlang VM. A workaround for this is to instruct
+  the process to periodically tell the VM to collect its garbage. This can be done by setting the
+  `gc_interval`.
+
+        use Absinthe.Phoenix.Socket,
+          schema: MyApp.Web.Schema,
+          gc_interval: 10_000
+
   """
 
   defmacro __using__(opts) do
@@ -37,6 +49,7 @@ defmodule Absinthe.Phoenix.Socket do
 
     schema = Keyword.get(opts, :schema)
     pipeline = Keyword.get(opts, :pipeline)
+    gc_interval = Keyword.get(opts, :gc_interval)
 
     quote do
       channel(
@@ -44,7 +57,8 @@ defmodule Absinthe.Phoenix.Socket do
         Absinthe.Phoenix.Channel,
         assigns: %{
           __absinthe_schema__: unquote(schema),
-          __absinthe_pipeline__: unquote(pipeline)
+          __absinthe_pipeline__: unquote(pipeline),
+          __absinthe_gc_interval: unquote(gc_interval)
         }
       )
     end


### PR DESCRIPTION
# Motivation
In our production environment, our Absinthe Graphql API, the processes responsible for handling subscriptions are accumulating garbage that is not being automatically collected by the Beam, up to 700Mb in some cases, that hang around for a good while. Manually running `:erlang.garbage_collect` on these processes would free up the consumption.

While it would be possible for us to create another process runs these gc calls for each of our user's processes, but I believe that it's better for this control to be on the process itself.

Related to #61 

Memory profile of the deployment after activating this fix, at around 13:00
![image](https://github.com/absinthe-graphql/absinthe_phoenix/assets/13839490/4915fdac-6222-4218-815f-4b3ec500e5d2)


Same period, of the day before
![image](https://github.com/absinthe-graphql/absinthe_phoenix/assets/13839490/7f2d6265-0d32-45da-b23a-31efade0b602)


It's is possible to notice that the memory consumption steadily grows overtime, and resets after a deployment.

Due to some peak memory usage, the application would sometimes OOM, which happened at 14:40 and 14:56 in the second image