### PR TITLE
Add supports to `Phoenix.HTML` v4.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -56,7 +56,7 @@ defmodule Absinthe.Phoenix.Mixfile do
       {:decimal, "~> 1.0 or ~> 2.0"},
       {:phoenix, "~> 1.5"},
       {:phoenix_pubsub, "~> 2.0"},
-      {:phoenix_html, "~> 2.13 or ~> 3.0", optional: true},
+      {:phoenix_html, "~> 2.13 or ~> 3.0 or ~> 4.0", optional: true},
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
       {:jason, "~> 1.0", only: [:dev, :test]}
     ]


### PR DESCRIPTION
This loosens the requirement for `Phoenix.HTML`, similar to what was done in other packages (see https://github.com/phoenixframework/phoenix_html/issues/399). Resolves #101.

