### PR TITLE
Add changelog entries for recently released versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## v2.0.3 - 2024-04-02
+
+- Add official support for Elixir 1.15 and OTP 26
+- Drop support for Elixir 1.10
+- Add support for `phoenix_html` 4.0
+- Add `:gc_interval` option to periodically run `:erlang.garbage_collect`, which can help with memory bloat (see [PR](https://github.com/absinthe-graphql/absinthe_phoenix/pull/100))
+
+## v2.0.2 - 2021-09-01
+
+- Add support for `phoenix_html` 3.0
+
+## v2.0.1 - 2021-02-09
+
+- Add support for `decimal` 2.0
+- Relax version requirement for Absinthe
+
 ## v2.0.0 - 2020-05-14
 
 - Phoenix.PubSub 2.0 support

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ def deps do
 end
 ```
 
-Note: Absinthe.Phoenix requires Elixir 1.10 or higher.
+Note: Absinthe.Phoenix requires Elixir 1.11 or higher.
 
 ## Upgrading
 


### PR DESCRIPTION
I was going to check the changelog before upgrading in my project, but I saw that the entries for recent versions are missing. So I decided to add them. I hope I didn't miss anything important.

Also, v2.0.3 is missing the tag in the repo (but this cannot be fixed in a PR, I think).