### PR TITLE
Add test case for when config/2 returns a map

### DIFF
--- a/test/absinthe/phoenix_test.exs
+++ b/test/absinthe/phoenix_test.exs
@@ -176,6 +176,18 @@ defmodule Absinthe.PhoenixTest do
     assert reply == %{errors: [%{locations: [%{column: 15, line: 1}], message: "unauthorized"}]}
   end
 
+  @tag :skip #TODO: update when absinthe's version is >= 1.8
+  test "config functions can return errors when returning map", %{socket: socket} do
+    ref =
+      push(socket, "doc", %{
+        "query" => "subscription {errorsMap { __typename }}"
+      })
+
+    assert_reply(ref, :error, reply)
+
+    assert reply == %{errors: [%{locations: [%{column: 15, line: 1}], message: "unauthorized", extensions: %{code: "UNAUTHORIZED"}}]}
+  end
+
   test "can't do multiple fields on a subscription root", %{socket: socket} do
     ref =
       push(socket, "doc", %{

--- a/test/absinthe/phoenix_test.exs
+++ b/test/absinthe/phoenix_test.exs
@@ -176,7 +176,8 @@ defmodule Absinthe.PhoenixTest do
     assert reply == %{errors: [%{locations: [%{column: 15, line: 1}], message: "unauthorized"}]}
   end
 
-  @tag :skip #TODO: update when absinthe's version is >= 1.8
+  # TODO: update when absinthe's version is >= 1.8
+  @tag :skip
   test "config functions can return errors when returning map", %{socket: socket} do
     ref =
       push(socket, "doc", %{
@@ -185,7 +186,15 @@ defmodule Absinthe.PhoenixTest do
 
     assert_reply(ref, :error, reply)
 
-    assert reply == %{errors: [%{locations: [%{column: 15, line: 1}], message: "unauthorized", extensions: %{code: "UNAUTHORIZED"}}]}
+    assert reply == %{
+             errors: [
+               %{
+                 locations: [%{column: 15, line: 1}],
+                 message: "unauthorized",
+                 extensions: %{code: "UNAUTHORIZED"}
+               }
+             ]
+           }
   end
 
   test "can't do multiple fields on a subscription root", %{socket: socket} do

--- a/test/support/schema.ex
+++ b/test/support/schema.ex
@@ -97,5 +97,11 @@ defmodule Schema do
         {:error, "unauthorized"}
       end
     end
+
+    field :errors_map, :comment do
+      config fn _, _ ->
+        {:error, %{message: "unauthorized", extensions: %{code: "UNAUTHORIZED"}}}
+      end
+    end
   end
 end


### PR DESCRIPTION
[A PR in absinthe](https://github.com/absinthe-graphql/absinthe/pull/1341) was merged that allows for return spec compliant error maps from `config/2` for subscriptions.

This PR adds a test for that case here. Since absinthe needs to be updated first, I skip it here. I have tried it using `absinthe` `main` and it passes.